### PR TITLE
Fix CORS pre-flight request failing with 401

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -60,7 +60,7 @@ class App(Flask):
 
     def __init__(self):
         super().__init__(__name__.split('.')[0])
-        CORS(self)
+        CORS(self, send_wildcard=True)
         config.load_file()
         self.config['JSONIFY_MIMETYPE'] = 'application/json'
         db.init_db()

--- a/app/auth.py
+++ b/app/auth.py
@@ -31,6 +31,8 @@ def check(admin=False):
 
 
 def need_user(admin=False):
+    if flask.request.method == 'OPTIONS':
+        return None
     user = _retrieve_user()
     if admin and not user.is_admin:
         raise InsufficientPermissions(

--- a/tests/simple_js_requests.html
+++ b/tests/simple_js_requests.html
@@ -1,0 +1,60 @@
+<!doctype html>
+
+<label for="token">Token</label>
+<input type="text" id="token" />
+
+<label for="url">URL</label>
+<input type="text" id="url" value="http://localhost:8000/api/listings/" />
+
+<button id="button">Call</button>
+
+<code id="result"></code>
+
+<style>
+    * {
+        box-sizing: border-box;
+    }
+
+    body {
+        padding: 2em;
+        max-width: 500px;
+        margin: auto;
+    }
+
+    input,
+    button,
+    code {
+        display: block;
+        width: 100%;
+        padding: 1em;
+        margin: 1em 0;
+    }
+
+    #result {
+        border: 1px solid #ccc;
+        white-space: pre;
+    }
+</style>
+
+<script>
+    const result_box = document.getElementById("result");
+    document.getElementById("button").onclick = async function () {
+        let result = '';
+        try {
+            const response = await fetch(
+                document.getElementById("url").value,
+                {
+                    method: 'GET',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': 'Bearer ' + document.getElementById("token").value
+                    }
+                },
+            );
+            result = await response.json();
+        } catch (error) {
+            result = error;
+        }
+        result_box.innerHTML = JSON.stringify(result, null, 2);
+    };
+</script>


### PR DESCRIPTION
pour la faire en simple, avant de faire sa vraie requête, le navigateur envoie une requête HTTP de type "OPTIONS" en s'attendant à recevoir des infos type "depuis quels URL accepte-tu les requêtes ? avec quel headers ? avec quel méthodes ?"

dans cette requête OPTIONS, le navigateur envoie pas genre Authorization: Bearer etc
![image](https://user-images.githubusercontent.com/9400466/205354290-28b79414-3a64-407d-952b-e8cae81b3d20.png)
dans notre réponse du coup flask-cors faisait bien son boulot et lui envoyait les 3 headers qu'on voit en bas du screen
![image](https://user-images.githubusercontent.com/9400466/205354333-1dfa0347-fc21-404b-908f-ee29a031ebe8.png)
mais la valeur de retour était 401 vu que mon code checkait les headers et trouvait pas de Authorization: Bearer dedans